### PR TITLE
Update and rename focusserver.py to SPIRO_live_view.py

### DIFF
--- a/SPIRO_live_view.py
+++ b/SPIRO_live_view.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 #
 # focusserver.py -
-#   live view web stream viewer for petripi.
+#   live view web stream viewer for SPIRO.
 #   useful for making focus adjustments.
-#   can be run standalone or through petripi commandline option.
+#   can be run standalone or through SPIRO commandline option.
 #
 # - Jonas Ohlsson <jonas.ohlsson .a. slu.se>
 #
@@ -15,14 +15,16 @@ import socketserver
 from threading import Condition
 from http import server
 from fractions import Fraction
+import time
+
 
 PAGE="""\
 <html>
 <head>
-<title>PetriPi live view</title>
+<title>SPIRO live view</title>
 </head>
 <body>
-<h1>PetriPi live view</h1>
+<h1>SPIRO live view</h1>
 <img src="stream.mjpg" width="1024" height="768" />
 <p>Zoom <a href="/zoom?-0.1">in</a> / <a href="/zoom?0.1">out</a></p>
 <p>Pan <a href="/panx?-0.1">left</a> / <a href="/panx?0.1">right</a> / <a href="/pany?-0.1">up</a> / <a href="/pany?0.1">down</a></p>
@@ -173,6 +175,6 @@ def focusServer(cam=None, myhw=hw):
         server = StreamingServer(address, StreamingHandler)
         server.serve_forever()
     except KeyboardInterrupt:
-        print("\nProgram ended by keyboard interrupt.")
+        print("  Quitting the SPIRO live view.")
     finally:
-        cam.stop_recording()
+        camera.stop_recording()


### PR DESCRIPTION
Further changes:

1. Links-> buttons
2. Place buttons according to the direction they indicate
3. Sync initial position with spiro.py
4. Sync focusing values with spiro.py. Please, make sure focusing values are taken into account for EVERY shot (implemented after exposure assessment?)
5. Check box for the reference grid
6. Add stop button to live view to stop recording + 6 sec power nap for the camera before user presses Ctrl+C

**Suggestion for an automated alignment script, since you like OpenCV so much**

- find the tiny dick (it is bolted to the cube now, so we can estimate approx. how many steps it is away from the initial position)
- make estimated number of steps
- Match reference points or text on the cube (scale bar should be always in the pic?) to the existing reference grid
- If doesn't match make more steps or step back (is it possible to estimate what direction and is preferential?)
- Re-match, if ok-> write the total n of steps made from tiny dick to the initial position into spiro.py