### PR TITLE
Release the lock before trying to send the stream

### DIFF
--- a/spiro/webui.py
+++ b/spiro/webui.py
@@ -251,13 +251,14 @@ def findstart(value=None):
 
 def liveGen():
     while True:
-        with liveoutput.condition:
-            if liveoutput.condition.wait(timeout=0.1):
-                frame = liveoutput.frame
-                yield (b'--frame\r\nContent-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
-            else:
-                # failed to acquire an image; return nothing instead of waiting
-                yield b''
+        with liveoutput.condition:            
+            got_frame = liveoutput.condition.wait(timeout=0.1):
+        if got_frame:
+            yield (b'--frame\r\nContent-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
+        else:
+            # failed to acquire an image; return nothing instead of waiting
+            yield b''
+            
 
 @not_while_running
 @app.route('/stream.mjpg')

--- a/spiro/webui.py
+++ b/spiro/webui.py
@@ -252,7 +252,7 @@ def findstart(value=None):
 def liveGen():
     while True:
         with liveoutput.condition:            
-            got_frame = liveoutput.condition.wait(timeout=0.1):
+            got_frame = liveoutput.condition.wait(timeout=0.1)
         if got_frame:
             yield (b'--frame\r\nContent-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
         else:


### PR DESCRIPTION
The context manager exits when the generator function resumes. This does not happen if the other end of the stream does not handle the yielded frame. This program illustrates how context managers work with generator functions:

```python
from contextlib import contextmanager

@contextmanager
def verbose():
    print('entering...')
    yield
    print('exiting...')

def hmm():
    with verbose():
        yield 1

it = hmm()
print(next(it))  # does not print "exiting..."
```